### PR TITLE
AM-1677: (HAL-01) Current Allowance Confirmation Can Be Bypassed

### DIFF
--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -5,6 +5,5 @@ pragma solidity ^0.8.17;
 library Errors {
     error InvalidTransfer(address from, address to, uint256 amount);
     error AddressZeroNotAllowed();
-    error WrongAllowance(uint256 allowance, uint256 currentAllowance);
     error SameValue();
 }

--- a/contracts/modules/wrapper/mandatory/ERC20BaseModule.sol
+++ b/contracts/modules/wrapper/mandatory/ERC20BaseModule.sol
@@ -87,27 +87,5 @@ abstract contract ERC20BaseModule is ERC20Upgradeable {
         return result;
     }
 
-    /**
-     * @dev See {IERC20-approve}.
-     *
-     * Requirements:
-     *
-     * - `spender` cannot be the zero address.
-     */
-    function approve(
-        address spender,
-        uint256 amount,
-        uint256 currentAllowance
-    ) public virtual returns (bool) {
-        if (allowance(_msgSender(), spender) != currentAllowance) {
-            revert Errors.WrongAllowance(
-                allowance(_msgSender(), spender),
-                currentAllowance
-            );
-        }
-        super.approve(spender, amount);
-        return true;
-    }
-
     uint256[50] private __gap;
 }

--- a/test/common/ERC20BaseModuleCommon.js
+++ b/test/common/ERC20BaseModuleCommon.js
@@ -1,6 +1,6 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 
-function BaseModuleCommon (owner, address1, address2, address3) {
+function ERC20BaseModuleCommon (owner, address1, address2, address3) {
   context('Token structure', function () {
     it('testHasTheDefinedName', async function () {
       // Act + Assert
@@ -119,57 +119,6 @@ function BaseModuleCommon (owner, address1, address2, address3) {
         value: '50'
       })
     })
-
-    it('testDefinedAllowanceByTakingInAccountTheCurrentAllowance', async function () {
-      // Arrange
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('0')
-      await this.cmtat.approve(address3, 20, { from: address1 });
-      // Arrange - Assert
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('20');
-      // Act
-      ({ logs: this.logs } = await this.cmtat.methods[
-        'approve(address,uint256,uint256)'
-      ](address3, 30, 20, { from: address1 }));
-      // Assert
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('30')
-      // emits an Approval event
-      expectEvent.inLogs(this.logs, 'Approval', {
-        owner: address1,
-        spender: address3,
-        value: '30'
-      })
-    })
-
-    it('testCannotDefinedAllowanceByTakingInAccountTheWrongCurrentAllowance', async function () {
-      // Arrange
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('0')
-      await this.cmtat.approve(address3, 20, { from: address1 });
-      // Arrange - Assert
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('20')
-      // Act
-      await expectRevert.unspecified(
-        this.cmtat.methods['approve(address,uint256,uint256)'](
-          address3,
-          30,
-          10,
-          { from: address1 }
-        )
-      );
-      // Assert
-      (
-        await this.cmtat.allowance(address1, address3)
-      ).should.be.bignumber.equal('20')
-    })
   })
 
   context('Transfer', function () {
@@ -271,4 +220,4 @@ function BaseModuleCommon (owner, address1, address2, address3) {
     })
   })
 }
-module.exports = BaseModuleCommon
+module.exports = ERC20BaseModuleCommon

--- a/test/proxy/modules/ERC20BaseModule.test.js
+++ b/test/proxy/modules/ERC20BaseModule.test.js
@@ -1,6 +1,6 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const CMTAT = artifacts.require('CMTAT_BASE')
-const ERC20BaseModuleCommon = require('../../common/BaseModuleCommon')
+const ERC20BaseModuleCommon = require('../../common/ERC20BaseModuleCommon')
 
 contract(
   'Proxy - ERC20BaseModule',


### PR DESCRIPTION
Custom `approve` function that could be found in `ERC20BaseModule.sol` is not necessary given that `increaseAllowance()` can be called instead.

Fixes HAL-01