### PR TITLE
Deploy 21BTC manually to Arbitrium & Base Sepolia Tesnets

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -41,13 +41,13 @@
       "kind": "transparent"
     },
     {
-      "address": "0x1bE9d03BfC211D83CFf3ABDb94A75F9Db46e1334",
-      "txHash": "0x93e439036897a24206964ae1e3b45fa82fb4ae0283638120490337c6a4887744",
+      "address": "0x0d3bd40758dF4F79aaD316707FcB809CD4815Ffe",
+      "txHash": "0x2bd451fe71a7e85c3cce781678c6fefbc801bc2c92b71a99b15f602ebeebfd4e",
       "kind": "transparent"
     },
     {
-      "address": "0x0d3bd40758dF4F79aaD316707FcB809CD4815Ffe",
-      "txHash": "0x2bd451fe71a7e85c3cce781678c6fefbc801bc2c92b71a99b15f602ebeebfd4e",
+      "address": "0x1bE9d03BfC211D83CFf3ABDb94A75F9Db46e1334",
+      "txHash": "0x93e439036897a24206964ae1e3b45fa82fb4ae0283638120490337c6a4887744",
       "kind": "transparent"
     },
     {

--- a/.openzeppelin/unknown-421614.json
+++ b/.openzeppelin/unknown-421614.json
@@ -1,0 +1,310 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xFe0D2F86cE8854C1c2081aB9e47D08374afB737F",
+    "txHash": "0xad1e6c465c23ca6fc77bfc8c70b67fe9907bf0f968d2c4faddef60b088bca926"
+  },
+  "proxies": [
+    {
+      "address": "0x3f67093dfFD4F0aF4f2918703C92B60ACB7AD78b",
+      "txHash": "0xb75cf147b8aaf2e33f0cc049028f703a7ac692ca4ea258812b5a70593817884f",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "946bbeec1ea22aaaeb7c7bd5038bbff42663e67c566214749561898491ffacba": {
+      "address": "0xF2753202BA39dD25eA8D6D1D609a9021234943Fc",
+      "txHash": "0xe1b1340fb0e78faef3c5fb2128b55d33f3b398f0343491211d591a33cb6ee157",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:37"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:400"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)886_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "AuthorizationModule",
+            "src": "contracts/modules/security/AuthorizationModule.sol:57"
+          },
+          {
+            "label": "tokenId",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:23"
+          },
+          {
+            "label": "terms",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:24"
+          },
+          {
+            "label": "information",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:25"
+          },
+          {
+            "label": "flag",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_uint256",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:26"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:109"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "355",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PauseModule",
+            "src": "contracts/modules/wrapper/mandatory/PauseModule.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "MintModule",
+            "src": "contracts/modules/wrapper/mandatory/MintModule.sol:51"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "455",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "BurnModule",
+            "src": "contracts/modules/wrapper/mandatory/BurnModule.sol:51"
+          },
+          {
+            "label": "_decimals",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_uint8",
+            "contract": "ERC20BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/ERC20BaseModule.sol:16"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/ERC20BaseModule.sol:90"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "CMTAT_BASE",
+            "src": "contracts/modules/CMTAT_BASE.sol:139"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)886_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)886_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      },
+      "allAddresses": [
+        "0x73225F88fEEA4E41Fc67E986a95AC61dd7118866"
+      ]
+    }
+  }
+}

--- a/.openzeppelin/unknown-84532.json
+++ b/.openzeppelin/unknown-84532.json
@@ -1,0 +1,307 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xFe0D2F86cE8854C1c2081aB9e47D08374afB737F",
+    "txHash": "0x128128f31b21e75164924d7893a162f4fb099eb01e3a1d791d69cfafc54635d3"
+  },
+  "proxies": [
+    {
+      "address": "0x3f67093dfFD4F0aF4f2918703C92B60ACB7AD78b",
+      "txHash": "0xb9b17aba85b109ec382c8afa12280e38950b7dc61780a50fd9b1f29d01cd408c",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "946bbeec1ea22aaaeb7c7bd5038bbff42663e67c566214749561898491ffacba": {
+      "address": "0xF2753202BA39dD25eA8D6D1D609a9021234943Fc",
+      "txHash": "0x7c3c7e2b406f8b8a80c1ee1e649dc02a57b0748a0296912e67a3c3e3d619c55f",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:37"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol:400"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)2191_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "AuthorizationModule",
+            "src": "contracts/modules/security/AuthorizationModule.sol:57"
+          },
+          {
+            "label": "tokenId",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:23"
+          },
+          {
+            "label": "terms",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:24"
+          },
+          {
+            "label": "information",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_string_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:25"
+          },
+          {
+            "label": "flag",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_uint256",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:26"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/BaseModule.sol:109"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "355",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PauseModule",
+            "src": "contracts/modules/wrapper/mandatory/PauseModule.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "MintModule",
+            "src": "contracts/modules/wrapper/mandatory/MintModule.sol:51"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "455",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "BurnModule",
+            "src": "contracts/modules/wrapper/mandatory/BurnModule.sol:51"
+          },
+          {
+            "label": "_decimals",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_uint8",
+            "contract": "ERC20BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/ERC20BaseModule.sol:16"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20BaseModule",
+            "src": "contracts/modules/wrapper/mandatory/ERC20BaseModule.sol:90"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "CMTAT_BASE",
+            "src": "contracts/modules/CMTAT_BASE.sol:139"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2191_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2191_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    }
+  }
+}

--- a/scripts/3_deploy_wrapped_assets_in_order.js
+++ b/scripts/3_deploy_wrapped_assets_in_order.js
@@ -1,0 +1,60 @@
+require('dotenv').config()
+const { ethers, upgrades } = require('hardhat')
+const {
+  getInitializerArguments,
+  printBoxedTitle
+} = require('./utils')
+
+async function deployWrappedAssets () {
+  printBoxedTitle('Deploying WRAPPED ASSETS to new network')
+
+  const [deployer] = await ethers.getSigners()
+
+  // First dummy transfer as nonce 0
+  await deployer.sendTransaction({
+    to: deployer.address,
+    value: 1 // Wei
+  })
+
+  // Deploy ProxyAdmin as nonce 1
+  const proxyAdminContract = await upgrades.deployProxyAdmin()
+  console.log('proxyAdmin', proxyAdminContract)
+
+  // Send 6 dummy transfers to get to nonce 7
+  for (let i = 0; i < 6; i++) {
+    await deployer.sendTransaction({
+      to: deployer.address,
+      value: 1 // Wei
+    })
+  }
+
+  // Deploy Implementation as nonce 8
+  const CMTATBase = await ethers.getContractFactory('CMTAT_BASE')
+  const deployedImplementation = await upgrades.deployImplementation(CMTATBase)
+  console.log('Implementation', await deployedImplementation.getAddress())
+
+  // Deploy 21BTC as nonce 9
+  const proxyContract = await upgrades.deployProxy(
+    CMTATBase,
+    getInitializerArguments(deployer.address),
+    { initializer: 'initialize' }
+  )
+
+  if (!proxyContract || !(await proxyContract.getAddress())) {
+    throw new Error('Deployment failed. Proxy contract address is undefined.')
+  }
+
+  console.log('Deployed contract object:\n', proxyContract)
+  console.log('@ : ', await proxyContract.getAddress())
+}
+
+async function main () {
+  try {
+    await deployWrappedAssets()
+  } catch (error) {
+    console.error('Deployment failed:', error)
+    process.exit(1)
+  }
+}
+
+main().then(() => process.exit(0))

--- a/scripts/3_deploy_wrapped_assets_in_order.js
+++ b/scripts/3_deploy_wrapped_assets_in_order.js
@@ -1,9 +1,9 @@
 require('dotenv').config()
 const { ethers, upgrades } = require('hardhat')
 const {
-  getInitializerArguments,
   printBoxedTitle
 } = require('./utils')
+const tokensMetadata = require('./wrapped-tokens.json');
 
 async function deployWrappedAssets () {
   printBoxedTitle('Deploying WRAPPED ASSETS to new network')
@@ -28,7 +28,7 @@ async function deployWrappedAssets () {
     })
   }
 
-  // // Deploy Implementation as nonce 8
+  // Deploy Implementation as nonce 8
   const CMTATBase = await ethers.getContractFactory('CMTAT_BASE')
   const deployedImplementation = await upgrades.deployImplementation(CMTATBase)
   console.log('Implementation', deployedImplementation)
@@ -36,7 +36,7 @@ async function deployWrappedAssets () {
   // Deploy 21BTC as nonce 9
   const proxyContract = await upgrades.deployProxy(
     CMTATBase,
-    getInitializerArguments(deployer.address),
+    tokensMetadata.tokens[0]['0x3f67093dfFD4F0aF4f2918703C92B60ACB7AD78b'].metadata,
     { initializer: 'initialize' }
   )
 

--- a/scripts/3_deploy_wrapped_assets_in_order.js
+++ b/scripts/3_deploy_wrapped_assets_in_order.js
@@ -28,10 +28,10 @@ async function deployWrappedAssets () {
     })
   }
 
-  // Deploy Implementation as nonce 8
+  // // Deploy Implementation as nonce 8
   const CMTATBase = await ethers.getContractFactory('CMTAT_BASE')
   const deployedImplementation = await upgrades.deployImplementation(CMTATBase)
-  console.log('Implementation', await deployedImplementation.getAddress())
+  console.log('Implementation', deployedImplementation)
 
   // Deploy 21BTC as nonce 9
   const proxyContract = await upgrades.deployProxy(

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,13 +10,13 @@ async function getAdminAddress () {
 function getInitializerArguments (admin) {
   return [
     admin, // Admin address
-    '21.co Wrapped Bitcoin',
-    '21BTC',
-    8,
-    '',
-    '',
-    '',
-    0
+    'Test CMTA Token', // nameIrrevocable
+    'TCMTAT', // symbolIrrevocable
+    18, // decimalsIrrevocable
+    'TCMTAT_ISIN', // tokenId
+    'https://cmta.ch', // terms
+    'TCMTAT_info', // information
+    0 // flag
   ]
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,13 +10,13 @@ async function getAdminAddress () {
 function getInitializerArguments (admin) {
   return [
     admin, // Admin address
-    'Test CMTA Token', // nameIrrevocable
-    'TCMTAT', // symbolIrrevocable
-    18, // decimalsIrrevocable
-    'TCMTAT_ISIN', // tokenId
-    'https://cmta.ch', // terms
-    'TCMTAT_info', // information
-    0 // flag
+    '21.co Wrapped Bitcoin',
+    '21BTC',
+    8,
+    '',
+    '',
+    '',
+    0
   ]
 }
 

--- a/scripts/wrapped-tokens.json
+++ b/scripts/wrapped-tokens.json
@@ -1,0 +1,190 @@
+{
+    "tokens": [
+        {
+            "0x3f67093dfFD4F0aF4f2918703C92B60ACB7AD78b": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Bitcoin",
+                    "21BTC",
+                    8,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 9
+            }
+        },
+        {
+            "0x0d3bd40758dF4F79aaD316707FcB809CD4815Ffe": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped XRP",
+                    "21XRP",
+                    6,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 10
+            }
+        },
+        {
+            "0x1bE9d03BfC211D83CFf3ABDb94A75F9Db46e1334": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped BNB",
+                    "21BNB",
+                    8,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 11
+            }
+        },
+        {
+            "0x9c05d54645306d4C4EAd6f75846000E1554c0360": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Cardano",
+                    "21ADA",
+                    6,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 12
+            }
+        },
+        {
+            "0xb80a1d87654BEf7aD8eB6BBDa3d2309E31D4e598": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Solana",
+                    "21SOL",
+                    9,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 13
+            }
+        },
+        {
+            "0x9F2825333aa7bC2C98c061924871B6C016e385F3": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Litecoin",
+                    "21LTC",
+                    8,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 14
+            }
+        },
+        {
+            "0xF4ACCD20bFED4dFFe06d4C85A7f9924b1d5dA819": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Polkadot",
+                    "21DOT",
+                    10,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 15
+            }
+        },
+        {
+            "0xFf4927e04c6a01868284F5C3fB9cba7F7ca4aeC0": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped BitcoinCash",
+                    "21BCH",
+                    8,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 16
+            }
+        },
+        {
+            "0x399508A43d7E2b4451cd344633108b4d84b33B03": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped AVAX",
+                    "21AVAX",
+                    18,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 20
+            }
+        },
+        {
+            "0x73225F88fEEA4E41Fc67E986a95AC61dd7118866": {
+                "metadata": [
+                    "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+                    "21.co Wrapped Toncoin",
+                    "21TON",
+                    9,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 26
+            }
+        },
+        {
+            "0xD2aEE1CE2b4459dE326971DE036E82f1318270AF": {
+                "metadata": [
+                    "0xDb611733293A7ce9Ac51b7ac382C55F96E537968",
+                    "21.co Wrapped Dogecoin",
+                    "21DOGE",
+                    8,
+                    "",
+                    "",
+                    "",
+                    0
+                ],
+                "nonce": 0
+            }
+        }
+    ],
+    "proxyAdmin": {
+        "deployer": "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+        "nonce": 1
+    },
+    "implementation": {
+        "deployer": "0x73E3552Cdbe9F4F38A1dDf1262b87Aa208d2225C",
+        "nonce": 8
+    },
+    "addresses": [
+        "0x3f67093dfFD4F0aF4f2918703C92B60ACB7AD78b",
+        "0x0d3bd40758dF4F79aaD316707FcB809CD4815Ffe",
+        "0x1bE9d03BfC211D83CFf3ABDb94A75F9Db46e1334",
+        "0x9c05d54645306d4C4EAd6f75846000E1554c0360",
+        "0xb80a1d87654BEf7aD8eB6BBDa3d2309E31D4e598",
+        "0x9F2825333aa7bC2C98c061924871B6C016e385F3",
+        "0xF4ACCD20bFED4dFFe06d4C85A7f9924b1d5dA819",
+        "0xFf4927e04c6a01868284F5C3fB9cba7F7ca4aeC0",
+        "0x399508A43d7E2b4451cd344633108b4d84b33B03",
+        "0x73225F88fEEA4E41Fc67E986a95AC61dd7118866",
+        "0xD2aEE1CE2b4459dE326971DE036E82f1318270AF"
+    ]
+}


### PR DESCRIPTION
- [21BTC](https://sepolia.arbiscan.io/address/0x3f67093dffd4f0af4f2918703c92b60acb7ad78b#code) on Arbitrum Sepolia
- [21BTC](https://sepolia.basescan.org/address/0x3f67093dffd4f0af4f2918703c92b60acb7ad78b) on Basenet Sepolia

Close [#AM-4840](https://21co.atlassian.net/browse/AM-4840)

Way to deploy:
`npx hardhat run scripts/3_deploy_wrapped_assets_in_order.js --network arbitrumTestnet`
`npx hardhat run scripts/3_deploy_wrapped_assets_in_order.js --network baseTesnet`